### PR TITLE
update scheduling algorithm:

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -109,7 +109,7 @@ func NewController(clientset *kubernetes.Clientset, kubeInformerFactory informer
 	// Create scheduler Cache
 	c.dealer, err = dealer.NewDealer(c.clientset, c.nodeLister, c.podLister, Rater)
 	if err != nil {
-		log.Error("create dealer failed: %s", err.Error())
+		log.Errorf("create dealer failed: %s", err.Error())
 		return nil, err
 	}
 
@@ -303,11 +303,11 @@ func (c *Controller) deletePodFromCache(obj interface{}) {
 		var ok bool
 		pod, ok = t.Obj.(*v1.Pod)
 		if !ok {
-			log.Warning("cannot convert to *v1.Pod: %v", t.Obj)
+			log.Warningf("cannot convert to *v1.Pod: %v", t.Obj)
 			return
 		}
 	default:
-		log.Warning("cannot convert to *v1.Pod: %v", t)
+		log.Warningf("cannot convert to *v1.Pod: %v", t)
 		return
 	}
 

--- a/pkg/dealer/allocate_test.go
+++ b/pkg/dealer/allocate_test.go
@@ -2,6 +2,7 @@ package dealer
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -186,4 +187,44 @@ func TestChoose(t *testing.T) {
 		_, err := choose.GPUs.Choose(choose.Demand, rater)
 		assert.Equal(t, choose.Success, err == nil)
 	}
+}
+
+func TestToSortableGPUs(t *testing.T) {
+	gpus := GPUs{
+		&GPUResource{80, 100},
+		&GPUResource{100, 100},
+		&GPUResource{30, 100},
+		&GPUResource{50, 100},
+	}
+
+	expected := SortableGPUs{
+		&GPUResourceWithIndex{&GPUResource{80, 100}, 0},
+		&GPUResourceWithIndex{&GPUResource{100, 100}, 1},
+		&GPUResourceWithIndex{&GPUResource{30, 100}, 2},
+		&GPUResourceWithIndex{&GPUResource{50, 100}, 3},
+	}
+
+	sortableGpus := gpus.ToSortableGPUs()
+
+	assert.Equal(t, len(sortableGpus), len(gpus))
+	assert.Equal(t, expected, sortableGpus)
+}
+
+func TestSortableGPUs(t *testing.T) {
+	gpus := SortableGPUs{
+		&GPUResourceWithIndex{&GPUResource{80, 100}, 0},
+		&GPUResourceWithIndex{&GPUResource{100, 100}, 1},
+		&GPUResourceWithIndex{&GPUResource{30, 100}, 2},
+		&GPUResourceWithIndex{&GPUResource{50, 100}, 3},
+	}
+	expected := SortableGPUs{
+		&GPUResourceWithIndex{&GPUResource{30, 100}, 2},
+		&GPUResourceWithIndex{&GPUResource{50, 100}, 3},
+		&GPUResourceWithIndex{&GPUResource{80, 100}, 0},
+		&GPUResourceWithIndex{&GPUResource{100, 100}, 1},
+	}
+
+	sort.Sort(gpus)
+
+	assert.Equal(t, expected, gpus)
 }

--- a/pkg/dealer/dealer.go
+++ b/pkg/dealer/dealer.go
@@ -108,6 +108,7 @@ func (d *DealerImpl) Assume(nodes []string, pod *v1.Pod) ([]bool, []error) {
 					if nodeInfos[number] == nil {
 						continue
 					}
+					nodeInfos[number].cleanPlan()
 					assumed, err := nodeInfos[number].Assume(demand)
 					ans[number] = assumed
 					res[number] = err

--- a/pkg/dealer/node.go
+++ b/pkg/dealer/node.go
@@ -44,9 +44,11 @@ func NewNodeInfo(name string, node *v1.Node, rater Rater) *NodeInfo {
 
 func (ni *NodeInfo) Assume(demand Demand) (bool, error) {
 	key := demand.Hash()
+
 	if _, ok := ni.PlanCache[key]; ok {
 		return true, nil
 	}
+
 	plan, err := ni.GPUs.Choose(demand, ni.Rater)
 	if err != nil {
 		return false, err

--- a/pkg/dealer/rater.go
+++ b/pkg/dealer/rater.go
@@ -1,6 +1,12 @@
 package dealer
 
-import "math"
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	log "k8s.io/klog/v2"
+)
 
 const (
 	ScoreMin = 0
@@ -9,6 +15,7 @@ const (
 
 type Rater interface {
 	Rate(GPUs, *Plan) int
+	Choose(GPUs, Demand) ([]int, error)
 }
 
 type SampleRater struct {
@@ -18,38 +25,128 @@ func (sr *SampleRater) Rate(GPUs, *Plan) int {
 	return ScoreMax
 }
 
+func (sr *SampleRater) Choose(gpus GPUs, d Demand) ([]int, error) {
+	indexes := []int{}
+	for _, r := range d {
+		if r.Percent == 0 {
+			indexes = append(indexes, NotNeedGPU)
+			continue
+		}
+		for j := 0; j < len(gpus); j++ {
+			if !gpus[j].CanAllocate(r) {
+				continue
+			}
+
+			indexes = append(indexes, j)
+			gpus[j].Percent -= r.Percent
+			break
+		}
+	}
+
+	if len(indexes) != len(d) {
+		return nil, fmt.Errorf("unexpected failure of allocation  %s on %s", d, gpus)
+	}
+	return indexes, nil
+}
+
 type Binpack struct {
 }
 
 type Spread struct {
 }
 
+// binpack will rate higher score to nodes with more usage and less gpus
 func (bp *Binpack) Rate(gpus GPUs, p *Plan) int {
 	usage := gpus.Usage()
 
-	return int(usage * 100)
+	return int(usage*100) - len(gpus)
 }
 
-// Spread expect to choose the node with less gpu usage
-// u: gpu usage of the node [0%, 100%]
-// v: variance of gpu usage of the node [0, 1]
-// g: transfer gpu number to a percent [0%, 100%]
-// spread = 7 * (1 - u) + 2 * (1 - g) + (1 - v)
-func (bp *Spread) Rate(gpus GPUs, p *Plan) int {
-	set := map[int]struct{}{}
-	for _, number := range p.GPUIndexes {
-		if number == -1 {
+// binpack will put as much conainters on same gpu card as possible, by
+// choosing gpu card with more usage
+func (bp *Binpack) Choose(gpus GPUs, d Demand) ([]int, error) {
+	indexes := []int{}
+
+	sortableGpus := gpus.ToSortableGPUs()
+
+	// we need to allocate from larger request to avoid allocation failure
+	sortableDemand := d.ToSortableGPUs()
+	sort.Sort(sortableDemand)
+	for j := len(sortableDemand) - 1; j >= 0; j-- {
+		if sortableDemand[j].Percent == 0 {
+			indexes = append(indexes, NotNeedGPU)
 			continue
 		}
-		set[number] = struct{}{}
+		sort.Sort(sortableGpus)
+		for i := 0; i < len(sortableGpus); i++ {
+			if !sortableGpus[i].CanAllocate(*sortableDemand[j].GPUResource) {
+				continue
+			}
+			indexes = append(indexes, sortableGpus[i].index)
+			sortableGpus[i].Percent -= sortableDemand[j].Percent
+			break
+		}
 	}
 
-	var (
-		u = gpus.Usage()
-		v = gpus.UsageVariance()
-		g = float64(len(set)) / float64(len(gpus))
-	)
-	return int(7*(1-u) + 2*(1-g) + (1 - v))
+	if len(indexes) != len(d) {
+		return nil, fmt.Errorf("can't allocate   %s on %s: indexes=%v", d, gpus, indexes)
+	}
+
+	resultIndexs := make([]int, len(d))
+	for j := len(d) - 1; j >= 0; j-- {
+		resultIndexs[sortableDemand[j].index] = indexes[len(d)-1-j]
+	}
+
+	log.Infof("d=%v,sortableDemand=%v, indexes=%v, resultIndexes=%v", d, sortableDemand, indexes, resultIndexs)
+
+	return resultIndexs, nil
+}
+
+// Spread expect to choose the node with more free gpu cards, more total available gpu and less gpus
+func (sp *Spread) Rate(gpus GPUs, p *Plan) int {
+	totalAvailable, freeGpuCount := gpus.PercentAvailableAndFreeGpuCount()
+
+	return 100*freeGpuCount + totalAvailable/10 - len(gpus)
+}
+
+// spread will spread conainters accross all gpu cards, by
+// choosing gpu card with less  usage
+func (sp *Spread) Choose(gpus GPUs, d Demand) ([]int, error) {
+	indexes := []int{}
+
+	sortableGpus := gpus.ToSortableGPUs()
+
+	// we need to allocate from larger request to avoid allocation failure
+	sortableDemand := d.ToSortableGPUs()
+	sort.Sort(sortableDemand)
+	for j := len(sortableDemand) - 1; j >= 0; j-- {
+		if sortableDemand[j].Percent == 0 {
+			indexes = append(indexes, NotNeedGPU)
+			continue
+		}
+		sort.Sort(sortableGpus)
+		for i := len(sortableGpus) - 1; i >= 0; i-- {
+			if !sortableGpus[i].CanAllocate(*sortableDemand[j].GPUResource) {
+				continue
+			}
+			indexes = append(indexes, sortableGpus[i].index)
+			sortableGpus[i].Percent -= sortableDemand[j].Percent
+			break
+		}
+	}
+
+	if len(indexes) != len(d) {
+		return nil, fmt.Errorf("can't allocate   %s on %s: indexes=%v", d, gpus, indexes)
+	}
+
+	resultIndexs := make([]int, len(d))
+	for j := len(d) - 1; j >= 0; j-- {
+		resultIndexs[sortableDemand[j].index] = indexes[len(d)-1-j]
+	}
+
+	log.Infof("d=%v,sortableDemand=%v, indexes=%v, resultIndexes=%v", d, sortableDemand, indexes, resultIndexs)
+
+	return resultIndexs, nil
 }
 
 func Variance(value []float64) float64 {

--- a/pkg/dealer/rater_test.go
+++ b/pkg/dealer/rater_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBinPack(t *testing.T) {
+func TestBinpackRate(t *testing.T) {
 	gpus1 := []*GPUResource{
 		{
 			Percent:      30,
@@ -34,5 +34,368 @@ func TestBinPack(t *testing.T) {
 	s2 := binpack.Rate(gpus2, nil)
 
 	assert.True(t, s1 < s2)
+}
 
+func TestSpreadRate(t *testing.T) {
+
+	testCases := []struct {
+		gpus1            GPUs
+		gpus2            GPUs
+		firstIsPreferred bool
+	}{{
+		gpus1: []*GPUResource{
+			{
+				Percent:      30,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      50,
+				PercentTotal: 100,
+			},
+		},
+		gpus2: []*GPUResource{
+			{
+				Percent:      20,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      40,
+				PercentTotal: 100,
+			},
+		},
+		firstIsPreferred: true,
+	}, {
+		gpus1: []*GPUResource{
+			{
+				Percent:      90,
+				PercentTotal: 100,
+			},
+		},
+		gpus2: []*GPUResource{
+			{
+				Percent:      50,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      40,
+				PercentTotal: 100,
+			},
+		},
+		firstIsPreferred: true,
+	}, {
+		gpus1: []*GPUResource{
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+		gpus2: []*GPUResource{
+			{
+				Percent:      50,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      50,
+				PercentTotal: 100,
+			},
+		},
+		firstIsPreferred: true,
+	}, {
+		gpus1: []*GPUResource{
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+		gpus2: []*GPUResource{
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      50,
+				PercentTotal: 100,
+			},
+		},
+		firstIsPreferred: false,
+	},
+	}
+	spread := &Spread{}
+
+	for _, testCase := range testCases {
+		s1 := spread.Rate(testCase.gpus1, nil)
+		s2 := spread.Rate(testCase.gpus2, nil)
+
+		assert.Equal(t, testCase.firstIsPreferred, s1 > s2)
+	}
+}
+
+func TestBinpackChoose(t *testing.T) {
+	testCases := []struct {
+		gpus         GPUs
+		demand       Demand
+		expected     []int
+		expectFailed bool
+	}{
+		{gpus: GPUs{
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{0, 0},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      20,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{0, 1},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      10,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{1, 1},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      0,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{-1, 0, 0},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      10,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      50,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected:     nil,
+			expectFailed: true,
+		},
+	}
+
+	binpack := &Binpack{}
+
+	for _, testCase := range testCases {
+		indexes, err := binpack.Choose(testCase.gpus, testCase.demand)
+		assert.Equal(t, testCase.expectFailed, err != nil)
+		if err == nil {
+			assert.Equal(t, testCase.expected, indexes)
+		}
+	}
+}
+
+func TestSpreadChoose(t *testing.T) {
+	testCases := []struct {
+		gpus         GPUs
+		demand       Demand
+		expected     []int
+		expectFailed bool
+	}{
+		{gpus: GPUs{
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{0, 1},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      20,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{1, 1},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      10,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{1, 1},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      100,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      0,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected: []int{-1, 0, 1},
+		},
+		{gpus: GPUs{
+			{
+				Percent:      10,
+				PercentTotal: 100,
+			},
+			{
+				Percent:      50,
+				PercentTotal: 100,
+			},
+		},
+			demand: Demand{
+				{
+					Percent:      20,
+					PercentTotal: 100,
+				},
+				{
+					Percent:      40,
+					PercentTotal: 100,
+				},
+			},
+			expected:     nil,
+			expectFailed: true,
+		},
+	}
+
+	spread := &Spread{}
+
+	for _, testCase := range testCases {
+		indexes, err := spread.Choose(testCase.gpus, testCase.demand)
+		assert.Equal(t, testCase.expectFailed, err != nil)
+		if err == nil {
+			assert.Equal(t, testCase.expected, indexes)
+		}
+	}
 }

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -74,7 +74,7 @@ func PredicateRoute(predicate *scheduler.Predicate) httprouter.Handle {
 
 		if resultBody, err := json.Marshal(extenderFilterResult); err != nil {
 			// panic(err)
-			log.Warning("Failed due to %v", err)
+			log.Warningf("Failed due to %v", err)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
 			errMsg := fmt.Sprintf("{'error':'%s'}", err.Error())
@@ -149,7 +149,7 @@ func BindRoute(bind *scheduler.Bind) httprouter.Handle {
 		}
 
 		if resultBody, err := json.Marshal(extenderBindingResult); err != nil {
-			log.Warningf("Failed due to ", err)
+			log.Warning("Failed due to ", err)
 			// panic(err)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
@@ -223,7 +223,7 @@ func StatusRoute(d dealer.Dealer) httprouter.Handle {
 		}
 
 		if resultBody, err := json.Marshal(nodeMaps); err != nil {
-			log.Warningf("failed due to ", err)
+			log.Warning("failed due to ", err)
 			// panic(err)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/scheduler/priority.go
+++ b/pkg/scheduler/priority.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	log "k8s.io/klog/v2"
 	extender "k8s.io/kube-scheduler/extender/v1"
 )
 
@@ -34,6 +35,7 @@ func NewNanoGPUPrioritize(ctx context.Context, clientset *kubernetes.Clientset, 
 					Score: int64(score),
 				}
 			}
+			log.Infof("node scores: %v", priorityList)
 			return &priorityList, nil
 		},
 	}


### PR DESCRIPTION
1. spread: choose the node with more free gpu cards, more total available gpu and less gpus
2. binpack: rate higher score to nodes with more usage and less gpus